### PR TITLE
(Backwardly compatibly) port examples to python3 and add "long" tests

### DIFF
--- a/src/liblo.pyx
+++ b/src/liblo.pyx
@@ -886,10 +886,7 @@ cdef class Message:
         cdef char t = ord(_decode(type)[0])
 
         if t == 'i':
-            try:
-                lo_message_add_int32(self._message, int(value))
-            except OverflowError:  #  No long type in python3
-                lo_message_add_int64(self._message, long(value))
+            lo_message_add_int32(self._message, int(value))
         elif t == 'h':
             lo_message_add_int64(self._message, long(value))
         elif t == 'f':

--- a/src/liblo.pyx
+++ b/src/liblo.pyx
@@ -886,7 +886,10 @@ cdef class Message:
         cdef char t = ord(_decode(type)[0])
 
         if t == 'i':
-            lo_message_add_int32(self._message, int(value))
+            try:
+                lo_message_add_int32(self._message, int(value))
+            except OverflowError:  #  No long type in python3
+                lo_message_add_int64(self._message, long(value))
         elif t == 'h':
             lo_message_add_int64(self._message, long(value))
         elif t == 'f':

--- a/test/example_client.py
+++ b/test/example_client.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import liblo, sys
 
 # send all messages to port 1234 on the local machine
 try:
     target = liblo.Address(1234)
-except liblo.AddressError, err:
-    print str(err)
+except liblo.AddressError as err:
+    print(err)
     sys.exit()
 
 # send message "/foo/message1" with int, float and string arguments

--- a/test/example_server.py
+++ b/test/example_server.py
@@ -1,26 +1,27 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import liblo, sys
 
 # create server, listening on port 1234
 try:
     server = liblo.Server(1234)
-except liblo.ServerError, err:
-    print str(err)
+except liblo.ServerError as err:
+    print(err)
     sys.exit()
 
 def foo_bar_callback(path, args):
     i, f = args
-    print "received message '%s' with arguments '%d' and '%f'" % (path, i, f)
+    print("received message '%s' with arguments '%d' and '%f'" % (path, i, f))
 
 def foo_baz_callback(path, args, types, src, data):
-    print "received message '%s'" % path
-    print "blob contains %d bytes, user data was '%s'" % (len(args[0]), data)
+    print("received message '%s'" % path)
+    print("blob contains %d bytes, user data was '%s'" % (len(args[0]), data))
 
 def fallback(path, args, types, src):
-    print "got unknown message '%s' from '%s'" % (path, src.get_url())
+    print("got unknown message '%s' from '%s'" % (path, src.get_url()))
     for a, t in zip(args, types):
-        print "argument of type '%s': %s" % (t, a)
+        print("argument of type '%s': %s" % (t, a))
 
 # register method taking an int and a float
 server.add_method("/foo/bar", 'if', foo_bar_callback)

--- a/test/example_server_deco.py
+++ b/test/example_server_deco.py
@@ -1,7 +1,14 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 from liblo import *
 import sys
+
+# raw_input renamed to input in python3
+try:
+    input = raw_input
+except NameError:
+    pass
 
 class MyServer(ServerThread):
     def __init__(self):
@@ -10,17 +17,17 @@ class MyServer(ServerThread):
     @make_method('/foo', 'ifs')
     def foo_callback(self, path, args):
         i, f, s = args
-        print "received message '%s' with arguments: %d, %f, %s" % (path, i, f, s)
+        print("received message '%s' with arguments: %d, %f, %s" % (path, i, f, s))
 
     @make_method(None, None)
     def fallback(self, path, args):
-        print "received unknown message '%s'" % path
+        print("received unknown message '%s'" % path)
 
 try:
     server = MyServer()
-except ServerError, err:
-    print str(err)
+except ServerError as err:
+    print(err)
     sys.exit()
 
 server.start()
-raw_input("press enter to quit...\n")
+input("press enter to quit...\n")

--- a/test/test_server_thread.py
+++ b/test/test_server_thread.py
@@ -36,7 +36,11 @@ st.add_method('/baz', 'b', b.baz_cb, 456)
 st.start()
 
 liblo.send(st.get_port(), "/foo", 123, 456.789, "buh!")
-liblo.send(st.get_port(), "/bar", 1234567890123456L, 666, ('c', "x"))
+try:
+    l = long(1234567890123456)
+except NameError:  # python3 does not have a long type
+    l = 1234567890123456
+liblo.send(st.get_port(), "/bar", l, 666, ('c', "x"))
 
 time.sleep(1)
 st.stop()

--- a/test/test_server_thread.py
+++ b/test/test_server_thread.py
@@ -36,10 +36,7 @@ st.add_method('/baz', 'b', b.baz_cb, 456)
 st.start()
 
 liblo.send(st.get_port(), "/foo", 123, 456.789, "buh!")
-try:
-    l = long(1234567890123456)
-except NameError:  # python3 does not have a long type
-    l = 1234567890123456
+l = 1234567890123456
 liblo.send(st.get_port(), "/bar", l, 666, ('c', "x"))
 
 time.sleep(1)

--- a/test/test_server_thread.py
+++ b/test/test_server_thread.py
@@ -1,30 +1,31 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import liblo
 import time
 
 st = liblo.ServerThread()
-print "Created Server Thread on Port", st.get_port()
+print("Created Server Thread on Port", st.get_port())
 
 def foo_cb(path, args, types):
-    print "foo_cb():"
+    print("foo_cb():")
     for a, t in zip(args, types):
-        print "received argument %s of type %s" % (a, t)
+        print("received argument %s of type %s" % (a, t))
 
 def bar_cb(path, args, types, src):
-    print "bar_cb():"
-    print "message from", src.get_url()
-    print "typespec:", types
+    print("bar_cb():")
+    print("message from", src.get_url())
+    print("typespec:", types)
     for a, t in zip(args, types):
-        print "received argument %s of type %s" % (a, t)
+        print("received argument %s of type %s" % (a, t))
 
 class Blah:
     def __init__(self, x):
         self.x = x
     def baz_cb(self, path, args, types, src, user_data):
-        print "baz_cb():"
-        print args[0]
-        print "self.x is", self.x, ", user data was", user_data
+        print("baz_cb():")
+        print(args[0])
+        print("self.x is", self.x, ", user data was", user_data)
 
 st.add_method('/foo', 'ifs', foo_cb)
 st.add_method('/bar', 'hdc', bar_cb)

--- a/test/unit.py
+++ b/test/unit.py
@@ -131,6 +131,11 @@ class ServerTestCase(ServerTestCaseBase):
         self.assertEqual(self.cb.types, 'h')
         self.assertEqual(self.cb.args[0], l)
 
+    def testSendingLongAsIntOverflows(self):
+        l = 1234567890123456
+        with self.assertRaises(OverflowError):
+            liblo.Message('/long', (l, 'i'))
+
     def testSendBundle(self):
         self.server.add_method('/foo', 'i', self.callback_dict)
         self.server.add_method('/bar', 's', self.callback_dict)

--- a/test/unit.py
+++ b/test/unit.py
@@ -123,10 +123,7 @@ class ServerTestCase(ServerTestCaseBase):
         assert self.cb.args[1] == 'foo'
 
     def testSendLong(self):
-        try:  # Python2
-            l = long(1234567890123456)
-        except NameError:  # Python3
-            l = 1234567890123456
+        l = 1234567890123456
         self.server.add_method('/long', 'h', self.callback)
         m = liblo.Message('/long', l)
         self.server.send(1234, m)

--- a/test/unit.py
+++ b/test/unit.py
@@ -122,6 +122,18 @@ class ServerTestCase(ServerTestCaseBase):
         assert self.cb.args[0] == 42
         assert self.cb.args[1] == 'foo'
 
+    def testSendLong(self):
+        try:  # Python2
+            l = long(1234567890123456)
+        except NameError:  # Python3
+            l = 1234567890123456
+        self.server.add_method('/long', 'h', self.callback)
+        m = liblo.Message('/long', l)
+        self.server.send(1234, m)
+        self.assertTrue(self.server.recv())
+        self.assertEqual(self.cb.types, 'h')
+        self.assertEqual(self.cb.args[0], l)
+
     def testSendBundle(self):
         self.server.add_method('/foo', 'i', self.callback_dict)
         self.server.add_method('/bar', 's', self.callback_dict)


### PR DESCRIPTION
Also fixed a bug around long handling (since the long type has gone away in python3).