### PR TITLE
send_osc: Add Workaround For Sending Null Char

### DIFF
--- a/scripts/send_osc.py
+++ b/scripts/send_osc.py
@@ -36,7 +36,10 @@ def make_message_manual(path, types, *args):
     msg = liblo.Message(path)
     try:
         for a, t in zip(args, types):
-            msg.add((t, a))
+            if t == 'c' and len(a) == 0: #workaround for sending null character
+                msg.add((t,"\0"))
+            else:
+                msg.add((t, a))
     except Exception as e:
         sys.exit(str(e))
 


### PR DESCRIPTION
When a null character is passed to send_osc via
send_osc PORT /path ,c $'\x00'
then an empty string is handed to the _add method.

Interpreting an empty string as the null character works around this issue.