### PR TITLE
Serialisation and Message introspection

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -77,6 +77,9 @@ Utility Classes
     .. automethod:: __init__
     .. automethod:: deserialise
     .. automethod:: serialise
+    .. autoattribute:: path
+    .. autoattribute:: args
+    .. autoattribute:: types
 
 .. autoclass:: Bundle
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -75,6 +75,8 @@ Utility Classes
 .. autoclass:: Message
 
     .. automethod:: __init__
+    .. automethod:: deserialise
+    .. automethod:: serialise
 
 .. autoclass:: Bundle
 

--- a/src/liblo.pxd
+++ b/src/liblo.pxd
@@ -102,6 +102,8 @@ cdef extern from 'lo/lo.h':
     void lo_message_add_blob(lo_message m, lo_blob a)
     lo_address lo_message_get_source(lo_message m)
     void* lo_message_serialise(lo_message m, const char* path, void* to, size_t* size)
+    lo_message lo_message_deserialise(void* data, size_t size, int* result)
+    char* lo_get_path(void* data, size_t size)
 
     # blob
     lo_blob lo_blob_new(int32_t size, void *data)

--- a/src/liblo.pxd
+++ b/src/liblo.pxd
@@ -101,6 +101,7 @@ cdef extern from 'lo/lo.h':
     void lo_message_add_timetag(lo_message m, lo_timetag a)
     void lo_message_add_blob(lo_message m, lo_blob a)
     lo_address lo_message_get_source(lo_message m)
+    void* lo_message_serialise(lo_message m, const char* path, void* to, size_t* size)
 
     # blob
     lo_blob lo_blob_new(int32_t size, void *data)

--- a/src/liblo.pxd
+++ b/src/liblo.pxd
@@ -101,9 +101,12 @@ cdef extern from 'lo/lo.h':
     void lo_message_add_timetag(lo_message m, lo_timetag a)
     void lo_message_add_blob(lo_message m, lo_blob a)
     lo_address lo_message_get_source(lo_message m)
-    void* lo_message_serialise(lo_message m, const char* path, void* to, size_t* size)
+    void* lo_message_serialise(
+        lo_message m, const char* path, void* to, size_t* size)
     lo_message lo_message_deserialise(void* data, size_t size, int* result)
     char* lo_get_path(void* data, size_t size)
+    char* lo_message_get_types(lo_message m)
+    lo_arg** lo_message_get_argv(lo_message m)
 
     # blob
     lo_blob lo_blob_new(int32_t size, void *data)

--- a/src/liblo.pyx
+++ b/src/liblo.pyx
@@ -1023,7 +1023,10 @@ cdef class Message:
     def serialise(self):
         cdef size_t length = 0
         cdef char* buf = <char*> lo_message_serialise(self._message, self._path, NULL, &length)
-        return buf[:length]
+        try:
+            return buf[:length]
+        finally:
+            free(buf)
 
 
 ################################################################################

--- a/src/liblo.pyx
+++ b/src/liblo.pyx
@@ -1020,6 +1020,11 @@ cdef class Message:
                 raise TypeError("unsupported message argument type")
             self._add('b', value)
 
+    def serialise(self):
+        cdef size_t length = 0
+        cdef char* buf = <char*> lo_message_serialise(self._message, self._path, NULL, &length)
+        return buf[:length]
+
 
 ################################################################################
 #  Bundle

--- a/src/liblo.pyx
+++ b/src/liblo.pyx
@@ -945,6 +945,12 @@ cdef class Message:
 
     @classmethod
     def deserialise(cls, buf):
+        """
+        deserialise(buf)
+
+        Create a new :class:`!Message` object from its on-the-wire byte string
+        representation.
+        """
         return cls(_deserialising, buf)
 
     def __dealloc__(self):
@@ -1042,6 +1048,12 @@ cdef class Message:
             self._add('b', value)
 
     def serialise(self):
+        """
+        serialise()
+
+        Serialise this :class:`!Message` object to its on-the-wire byte string
+        representation.
+        """
         cdef size_t length = 0
         cdef char* buf = <char*> lo_message_serialise(
             self._message, self._path, NULL, &length)

--- a/src/liblo.pyx
+++ b/src/liblo.pyx
@@ -1062,20 +1062,29 @@ cdef class Message:
         finally:
             free(buf)
 
-    @property
-    def path(self):
-        return _decode(self._path)
+    property path:
+        """
+        The path of this :class:`!Message`
+        """
+        def __get__(self):
+            return _decode(self._path)
 
-    @property
-    def types(self):
-        cdef char* buf = lo_message_get_types(self._message)
-        return _decode(buf)
+    property types:
+        """
+        A string of the typetags of the arguments of this :class:`!Message`
+        """
+        def __get__(self):
+            cdef char* buf = lo_message_get_types(self._message)
+            return _decode(buf)
 
-    @property
-    def args(self):
-        return _extract_args(
-            lo_message_get_types(self._message),
-            lo_message_get_argv(self._message))
+    property args:
+        """
+        A list of the argument values of this :class:`!Message`
+        """
+        def __get__(self):
+            return _extract_args(
+                lo_message_get_types(self._message),
+                lo_message_get_argv(self._message))
 
 
 ################################################################################

--- a/test/test_liblo.py
+++ b/test/test_liblo.py
@@ -359,26 +359,22 @@ class MessageTestCase(unittest.TestCase):
         ('b', b'mrblobby'),
     )
 
-    def assertListsAlmostEqual(self, a, b):
-        self.assertEqual(len(a), len(b))
-        for ai, bi in zip(a, b):
-            if isinstance(ai, float):
-                self.assertAlmostEqual(ai, bi, delta=0.000001)
-            else:
-                self.assertEqual(ai, bi)
-
     def testPath(self):
         m = liblo.Message('/some/path/')
         self.assertEqual(m.path, '/some/path/')
 
-    def testTypes(self):
+    def testArgsAndTypes(self):
         m = liblo.Message('/', *self.example_data)
-        self.assertEqual(m.types, ''.join(a[0] for a in self.example_data))
-
-    def testArgs(self):
-        m = liblo.Message('/', *self.example_data)
-        self.assertListsAlmostEqual(
-            m.args, list(a[1] for a in self.example_data))
+        self.assertEqual(len(m.types), len(self.example_data))
+        for at, aa, (et, ea) in zip(m.types, m.args, self.example_data):
+            self.assertEqual(at, et)
+            if isinstance(aa, float):
+                self.assertAlmostEqual(aa, ea, delta=0.000001)
+            elif at == 'b' and isinstance(aa, list):
+                # Python 2 compataibility for byte handling
+                self.assertEqual(''.join(map(chr, aa)), ea)
+            else:
+                self.assertEqual(aa, ea)
 
     def testSerialisation(self):
         m1 = liblo.Message('/', *self.example_data)

--- a/test/test_liblo.py
+++ b/test/test_liblo.py
@@ -341,5 +341,53 @@ class AddressTestCase(unittest.TestCase):
         self.assertEqual(a.url, 'osc.tcp://foo:1234/')
 
 
+class MessageTestCase(unittest.TestCase):
+    example_data = (
+        ('i', 42),
+        ('h', 43),
+        ('f', 4.2),
+        ('d', 4.3),
+        ('c', 'A'),
+        ('s', 'hello'),
+        ('S', 'world'),
+        ('T', True),
+        ('F', False),
+        ('N', None),
+        ('I', float('inf')),
+        ('m', (1, 2, 4, 5)),
+        ('t', 4444.44),
+        ('b', b'mrblobby'),
+    )
+
+    def assertListsAlmostEqual(self, a, b):
+        self.assertEqual(len(a), len(b))
+        for ai, bi in zip(a, b):
+            if isinstance(ai, float):
+                self.assertAlmostEqual(ai, bi, delta=0.000001)
+            else:
+                self.assertEqual(ai, bi)
+
+    def testPath(self):
+        m = liblo.Message('/some/path/')
+        self.assertEqual(m.path, '/some/path/')
+
+    def testTypes(self):
+        m = liblo.Message('/', *self.example_data)
+        self.assertEqual(m.types, ''.join(a[0] for a in self.example_data))
+
+    def testArgs(self):
+        m = liblo.Message('/', *self.example_data)
+        self.assertListsAlmostEqual(
+            m.args, list(a[1] for a in self.example_data))
+
+    def testSerialisation(self):
+        m1 = liblo.Message('/', *self.example_data)
+        b = m1.serialise()
+        self.assertIsInstance(b, bytes)
+        m2 = liblo.Message.deserialise(b)
+        self.assertEqual(m1.path, m2.path)
+        self.assertEqual(m1.args, m2.args)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR adds some introspection to Message objects so one can see what args they contain (useful for debugging) and exposes the message serialisation/deserialisation (useful for applications that don't actually want to send messages via `liblo`'s server, but do want to use its message processing).

Caveat: I'm quite new to Cython, so please check this carefully! Especially around the binary blob handing - mostly my tests pass, but sometimes they don't and I get strange trailing data in the blob.
