### PR TITLE
Permit enabling SLIP on data transmissions

### DIFF
--- a/src/liblo.pxd
+++ b/src/liblo.pxd
@@ -81,6 +81,7 @@ cdef extern from 'lo/lo.h':
     char *lo_address_get_hostname(lo_address a)
     char *lo_address_get_port(lo_address a)
     int lo_address_get_protocol(lo_address a)
+    int lo_address_set_stream_slip(lo_address a, int enable)
     const_char* lo_address_errstr(lo_address a)
 
     # message

--- a/src/liblo.pyx
+++ b/src/liblo.pyx
@@ -842,6 +842,9 @@ cdef class Address:
     def get_protocol(self):
         return lo_address_get_protocol(self._address)
 
+    def set_slip_enabled(self, enable):
+        lo_address_set_stream_slip(self._address, int(enable))
+
     property url:
         """
         The address's URL.


### PR DESCRIPTION
* SLIP is defined in RFC1055 : https://tools.ietf.org/rfc/rfc1055.txt
* OSC v1.1 requires use of it;
* The underlying `liblo` library has supported it for a while;

This PR allows users of this python mapping to enable SLIP for outgoing streams to a specific address/destination. (Incoming streams with SLIP encoding are detected and decoded automatically by `liblo`.)